### PR TITLE
Parse configuration returned on set

### DIFF
--- a/docs/source/user.rst
+++ b/docs/source/user.rst
@@ -90,7 +90,7 @@ functions.
   >>> kik = KikApi(BOT_USERNAME, BOT_API_KEY)
   >>> config = Configuration(webhook='https://example.com/incoming')
   >>> kik.set_configuration(config)
-  {}
+  <kik.Configuration>
 
 Receiving Messages
 ------------------

--- a/kik/api.py
+++ b/kik/api.py
@@ -212,8 +212,9 @@ class KikApi(object):
 
         :param config: A :class:`Configuration<kik.Configuration>` containing your bot's new configuration
         :type config: kik.Configuration
-        :returns: A dict containing the response from the API.
-        :rtype: dict
+        :returns: A :class:`Configuration<kik.Configuration>` containing your bot's new configuration, as confirmed by
+        the server
+        :rtype: kik.Configuration
 
         Usage:
 
@@ -221,7 +222,7 @@ class KikApi(object):
         >>> kik = KikApi(BOT_USERNAME, BOT_API_KEY)
         >>> config = Configuration(webhook='https://example.com/incoming')
         >>> kik.set_configuration(config)
-        {}
+        <kik.Configuration>
         """
         response = requests.post(
             ROOT_URL.format('/v1/config'),

--- a/kik/api.py
+++ b/kik/api.py
@@ -236,7 +236,7 @@ class KikApi(object):
         if response.status_code != 200:
             raise KikError(response.text)
 
-        return response.json()
+        return Configuration.from_json(response.json())
 
     def verify_signature(self, signature, body):
         """

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -170,7 +170,12 @@ class KikBotApiTest(TestCase):
         self.assertEqual(config.webhook, 'https://example.com/incoming')
         self.assertEqual(config.features, {'manuallySendReadReceipts': True})
 
-    @mock.patch('requests.post', return_value=_response(200, json.dumps({}).encode('utf-8')))
+    @mock.patch('requests.post', return_value=_response(200, json.dumps({
+        'webhook': 'https://example.com/incoming',
+        'features': {
+            'manuallySendReadReceipts': True
+        }
+    }).encode('utf-8')))
     def test_set_configuration(self, post):
         config = Configuration(
             webhook='https://example.com/incoming',
@@ -191,4 +196,6 @@ class KikBotApiTest(TestCase):
             }
         })
 
-        self.assertEqual(response, {})
+        self.assertIsInstance(response, Configuration)
+        self.assertEqual(response.webhook, 'https://example.com/incoming')
+        self.assertEqual(response.features, {'manuallySendReadReceipts': True})


### PR DESCRIPTION
The configuration API has been changed server-side to return the configuration that was just set. This PR parses the response back into a Configuration object.