### PR TITLE
Bug Fix: Empty responses fails when sending messages

### DIFF
--- a/kik/messages/keyboard_message.py
+++ b/kik/messages/keyboard_message.py
@@ -5,6 +5,7 @@ class KeyboardMessage(Message):
     """
     Parent class for messages that support keyboards.
     """
+
     def __init__(self, keyboards=None, **kwargs):
         super(KeyboardMessage, self).__init__(**kwargs)
         if keyboards:
@@ -14,7 +15,9 @@ class KeyboardMessage(Message):
 
     def to_json(self):
         output_json = super(KeyboardMessage, self).to_json()
-        if len(self.keyboards) > 0 and any([keyboard.responses for keyboard in self.keyboards]):
+        non_empty_srs = any([keyboard.responses if hasattr(keyboard, 'responses') else True
+                             for keyboard in self.keyboards])
+        if len(self.keyboards) > 0 and non_empty_srs:
             output_json['keyboards'] = [keyboard.to_json() for keyboard in self.keyboards if keyboard.responses]
 
         return output_json

--- a/kik/messages/keyboard_message.py
+++ b/kik/messages/keyboard_message.py
@@ -14,7 +14,7 @@ class KeyboardMessage(Message):
 
     def to_json(self):
         output_json = super(KeyboardMessage, self).to_json()
-        if len(self.keyboards) > 0:
+        if len(self.keyboards) > 0 and all([len(k.responses) > 0 for k in self.keyboards]):
             output_json['keyboards'] = [keyboard.to_json() for keyboard in self.keyboards]
 
         return output_json

--- a/kik/messages/keyboard_message.py
+++ b/kik/messages/keyboard_message.py
@@ -14,7 +14,7 @@ class KeyboardMessage(Message):
 
     def to_json(self):
         output_json = super(KeyboardMessage, self).to_json()
-        if len(self.keyboards) > 0 and all([len(k.responses) > 0 for k in self.keyboards]):
-            output_json['keyboards'] = [keyboard.to_json() for keyboard in self.keyboards]
+        if len(self.keyboards) > 0 and any([k.responses for k in self.keyboards]):
+            output_json['keyboards'] = [keyboard.to_json() for keyboard in self.keyboards if keyboard.responses]
 
         return output_json

--- a/kik/messages/keyboard_message.py
+++ b/kik/messages/keyboard_message.py
@@ -14,7 +14,7 @@ class KeyboardMessage(Message):
 
     def to_json(self):
         output_json = super(KeyboardMessage, self).to_json()
-        if len(self.keyboards) > 0 and any([k.responses for k in self.keyboards]):
+        if len(self.keyboards) > 0 and any([keyboard.responses for keyboard in self.keyboards]):
             output_json['keyboards'] = [keyboard.to_json() for keyboard in self.keyboards if keyboard.responses]
 
         return output_json

--- a/test/messages/test_messages.py
+++ b/test/messages/test_messages.py
@@ -59,8 +59,8 @@ class KikBotMessagesTest(TestCase):
             id='8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e1',
             keyboards=[
                 SuggestedResponseKeyboard(
-                    hidden=True,
-                    responses=None)
+                    responses=None
+                )
             ]
         ).to_json()
         self.assertEqual(message, {

--- a/test/messages/test_messages.py
+++ b/test/messages/test_messages.py
@@ -52,6 +52,24 @@ class KikBotMessagesTest(TestCase):
             ]
         })
 
+    def test_text_message_with_keyboard_with_no_responses(self):
+        message = TextMessage(
+            body='Some text',
+            to='kevin',
+            id='8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e1',
+            keyboards=[
+                SuggestedResponseKeyboard(
+                    hidden=True,
+                    responses=None)
+            ]
+        ).to_json()
+        self.assertEqual(message, {
+            'type': 'text',
+            'to': 'kevin',
+            'body': 'Some text',
+            'id': '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e1'
+        })
+
     def test_text_message_delay(self):
         message = TextMessage(body='Some text', to='aleem', delay=1500).to_json()
         self.assertEqual(message, {


### PR DESCRIPTION
Sending Messages with empty responses for a SuggestedResponseKeyboard fails.

Only adds a keyboard if their are responses for the keyboard.