### PR TITLE
Do not modify arguments to `messages_from_json`

### DIFF
--- a/kik/messages/utils.py
+++ b/kik/messages/utils.py
@@ -26,9 +26,11 @@ def messages_from_json(messages):
     """
     message_objects = []
     for message in messages:
-        msg_type = incoming_type_mapping.get(message['type'], UnknownMessage)
-        if msg_type is not UnknownMessage:
+        msg_type = message['type']
+        msg_cls = incoming_type_mapping.get(msg_type, UnknownMessage)
+        if msg_cls is not UnknownMessage:
             # Unknown message types want to keep the type param, as it's not otherwise accessible.
             del message['type']
-        message_objects.append(msg_type.from_json(message))
+        message_objects.append(msg_cls.from_json(message))
+        message['type'] = msg_type
     return message_objects

--- a/test/messages/test_utils.py
+++ b/test/messages/test_utils.py
@@ -17,6 +17,7 @@ class MessageUtilsTest(TestCase):
         self.assertEqual(output[0].type, 'text')
         self.assertEqual(output[0].from_user, 'aleem')
         self.assertEqual(output[0].body, 'Yo text message!')
+        self.assertEqual(input[0]['type'], 'text')
 
     def test_multiple_elements(self):
         input = [{'type': 'text', 'from': 'aleem', 'body': 'Yo text message!'},
@@ -27,10 +28,12 @@ class MessageUtilsTest(TestCase):
         self.assertEqual(output[0].type, 'text')
         self.assertEqual(output[0].from_user, 'aleem')
         self.assertEqual(output[0].body, 'Yo text message!')
+        self.assertEqual(input[0]['type'], 'text')
         self.assertIsInstance(output[1], LinkMessage)
         self.assertEqual(output[1].type, 'link')
         self.assertEqual(output[1].from_user, 'laura')
         self.assertEqual(output[1].url, 'http://yo.text/message')
+        self.assertEqual(input[1]['type'], 'link')
 
     def test_unknown_message(self):
         input = [{'type': 'some-unknown-type', 'from': 'aleem', 'to': 'laura', 'someProperty': 'aValue'}]
@@ -41,3 +44,4 @@ class MessageUtilsTest(TestCase):
         self.assertEqual(output[0].from_user, 'aleem')
         self.assertEqual(output[0].to, 'laura')
         self.assertEqual(output[0].raw_message, input[0])
+        self.assertEqual(input[0]['type'], 'some-unknown-type')


### PR DESCRIPTION
`messages_from_json` currently deletes the `type` key for each message passed to the function - now it doesn't.