### PR TITLE
Include keyboards when parsing messages from JSON

### DIFF
--- a/kik/messages/__init__.py
+++ b/kik/messages/__init__.py
@@ -9,13 +9,13 @@ from kik.messages.text import TextMessage
 from kik.messages.unknown import UnknownMessage
 from kik.messages.video import VideoMessage
 from kik.messages.utils import messages_from_json
-from kik.messages.keyboards import SuggestedResponseKeyboard
-from kik.messages.responses import TextResponse
+from kik.messages.keyboards import SuggestedResponseKeyboard, UnknownKeyboard
+from kik.messages.responses import TextResponse, UnknownResponse
 from kik.messages.attribution import CustomAttribution, PresetAttributions
 from kik.messages.message import Message
 
 
 __all__ = ['TextMessage', 'LinkMessage', 'PictureMessage', 'ScanDataMessage', 'StartChattingMessage', 'StickerMessage',
            'VideoMessage', 'IsTypingMessage', 'ReceiptMessage', 'ReadReceiptMessage', 'DeliveryReceiptMessage',
-           'UnknownMessage', 'SuggestedResponseKeyboard', 'TextResponse', 'messages_from_json', 'CustomAttribution',
-           'PresetAttributions', 'Message']
+           'UnknownMessage', 'SuggestedResponseKeyboard', 'UnknownKeyboard', 'TextResponse', 'UnknownResponse',
+           'messages_from_json', 'CustomAttribution', 'PresetAttributions', 'Message']

--- a/kik/messages/keyboard_message.py
+++ b/kik/messages/keyboard_message.py
@@ -1,4 +1,11 @@
+from kik.messages.keyboards import SuggestedResponseKeyboard, UnknownKeyboard
+
 from kik.messages.message import Message
+
+
+keyboard_type_mapping = {
+    'suggested': SuggestedResponseKeyboard
+}
 
 
 class KeyboardMessage(Message):
@@ -18,3 +25,22 @@ class KeyboardMessage(Message):
             output_json['keyboards'] = [keyboard.to_json() for keyboard in self.keyboards]
 
         return output_json
+
+    @classmethod
+    def from_json(cls, json):
+        message = super(KeyboardMessage, cls).from_json(json)
+
+        if 'keyboards' in json:
+            keyboards = []
+            for keyboard in json['keyboards']:
+                kb_type = keyboard['type']
+                kb_cls = keyboard_type_mapping.get(kb_type, UnknownKeyboard)
+                if kb_cls is not UnknownKeyboard:
+                    del keyboard['type']
+                keyboards.append(kb_cls.from_json(keyboard))
+                keyboard['type'] = kb_type
+
+            if len(keyboards) > 0:
+                message.keyboards = keyboards
+
+        return message

--- a/kik/messages/keyboard_message.py
+++ b/kik/messages/keyboard_message.py
@@ -1,5 +1,4 @@
 from kik.messages.keyboards import SuggestedResponseKeyboard, UnknownKeyboard
-
 from kik.messages.message import Message
 
 

--- a/kik/messages/responses.py
+++ b/kik/messages/responses.py
@@ -26,3 +26,30 @@ class TextResponse(SuggestedResponse):
         mapping = super(TextResponse, cls).property_mapping()
         mapping.update({'body': 'body'})
         return mapping
+
+
+class UnknownResponse(SuggestedResponse):
+    """
+    This response type is returned by the response factory when it encounters an unknown response type.
+
+    It's `type` attribute is set to the type of the response, and it's `raw_response` attribute contains the raw JSON
+    response received
+    """
+    @classmethod
+    def from_json(cls, json):
+        response = super(UnknownResponse, cls).from_json(json)
+        response.raw_response = json
+        return response
+
+    @classmethod
+    def property_mapping(cls):
+        mapping = super(UnknownResponse, cls).property_mapping()
+        mapping.update({
+            'type': 'type'
+        })
+        return mapping
+
+
+response_type_mapping = {
+    'text': TextResponse
+}

--- a/test/messages/test_messages_incoming.py
+++ b/test/messages/test_messages_incoming.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
 
 from kik.messages import VideoMessage, UnknownMessage, TextMessage, StartChattingMessage, StickerMessage, \
-    ScanDataMessage, PictureMessage, LinkMessage, IsTypingMessage, ReadReceiptMessage, DeliveryReceiptMessage
+    ScanDataMessage, PictureMessage, LinkMessage, IsTypingMessage, ReadReceiptMessage, DeliveryReceiptMessage, \
+    SuggestedResponseKeyboard, TextResponse
 
 
 class KikBotMessagesIncomingTest(TestCase):
@@ -270,3 +271,105 @@ class KikBotMessagesIncomingTest(TestCase):
         self.assertEqual(message.id, '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0')
         self.assertEqual(message.timestamp, 1458336131)
         self.assertIs(False, message.read_receipt_requested)
+
+    def test_suggested_keyboard_message(self):
+        message = TextMessage.from_json({
+            'to': 'aleem',
+            'participants': ['aleem'],
+            'chatId': 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2',
+            'body': 'Some text',
+            'id': '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0',
+            'timestamp': 1458336131,
+            'readReceiptRequested': True,
+            'keyboards': [
+                {
+                    'to': 'aleem',
+                    'type': 'suggested',
+                    'hidden': False,
+                    'responses': [
+                        {
+                            'type': 'text',
+                            'body': 'Ok!'
+                        },
+                        {
+                            'type': 'text',
+                            'body': 'No way!'
+                        }
+                    ]
+                }
+            ]
+        })
+
+        self.assertEqual(message.to, 'aleem')
+        self.assertEqual(message.participants, ['aleem'])
+        self.assertEqual(message.chat_id, 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
+        self.assertEqual(message.body, 'Some text')
+        self.assertEqual(message.id, '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0')
+        self.assertEqual(message.timestamp, 1458336131)
+        self.assertIs(True, message.read_receipt_requested)
+        responses = [TextResponse('Ok!'), TextResponse('No way!')]
+        self.assertEqual(message.keyboards, [SuggestedResponseKeyboard(to='aleem', hidden=False, responses=responses)])
+
+    def test_unknown_keyboard_message(self):
+        keyboard_json = {'to': 'aleem', 'type': 'some-unknown-type', 'hidden': False}
+        message = TextMessage.from_json({
+            'to': 'aleem',
+            'participants': ['aleem'],
+            'chatId': 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2',
+            'body': 'Some text',
+            'id': '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0',
+            'timestamp': 1458336131,
+            'readReceiptRequested': True,
+            'keyboards': [keyboard_json]
+        })
+
+        self.assertEqual(message.to, 'aleem')
+        self.assertEqual(message.participants, ['aleem'])
+        self.assertEqual(message.chat_id, 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
+        self.assertEqual(message.body, 'Some text')
+        self.assertEqual(message.id, '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0')
+        self.assertEqual(message.timestamp, 1458336131)
+        self.assertIs(True, message.read_receipt_requested)
+        self.assertIsInstance(message.keyboards, list)
+        self.assertEqual(len(message.keyboards), 1)
+        self.assertEqual(message.keyboards[0].to, 'aleem')
+        self.assertEqual(message.keyboards[0].type, 'some-unknown-type')
+        self.assertEqual(message.keyboards[0].hidden, False)
+        self.assertEqual(message.keyboards[0].raw_keyboard, keyboard_json)
+
+    def test_unknown_suggested_response(self):
+        response_json = {'type': 'some-unknown-type', 'prop': 'Ok!'}
+        message = TextMessage.from_json({
+            'to': 'aleem',
+            'participants': ['aleem'],
+            'chatId': 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2',
+            'body': 'Some text',
+            'id': '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0',
+            'timestamp': 1458336131,
+            'readReceiptRequested': True,
+            'keyboards': [
+                {
+                    'to': 'aleem',
+                    'type': 'suggested',
+                    'hidden': False,
+                    'responses': [response_json]
+                }
+            ]
+        })
+
+        self.assertEqual(message.to, 'aleem')
+        self.assertEqual(message.participants, ['aleem'])
+        self.assertEqual(message.chat_id, 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
+        self.assertEqual(message.body, 'Some text')
+        self.assertEqual(message.id, '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0')
+        self.assertEqual(message.timestamp, 1458336131)
+        self.assertIs(True, message.read_receipt_requested)
+        self.assertIsInstance(message.keyboards, list)
+        self.assertEqual(len(message.keyboards), 1)
+        self.assertEqual(message.keyboards[0].to, 'aleem')
+        self.assertEqual(message.keyboards[0].type, 'suggested')
+        self.assertEqual(message.keyboards[0].hidden, False)
+        self.assertIsInstance(message.keyboards[0].responses, list)
+        self.assertEqual(len(message.keyboards[0].responses), 1)
+        self.assertEqual(message.keyboards[0].responses[0].type, 'some-unknown-type')
+        self.assertEqual(message.keyboards[0].responses[0].raw_response, response_json)


### PR DESCRIPTION
Keyboards should be included when parsing messages from JSON -- now they are.

*Note:* variants of the following block of code now appear in 3 places (responses, keyboards, and messages) and has potential to show up in attribution. Might want to consider creating a general function for it.
```python
if 'responses' in json:
    for response in json['responses']:
        response_type = response['type']
        response_cls = response_type_mapping.get(response_type, UnknownResponse)
        if response_cls is not UnknownResponse:
            del response['type']
        keyboard.responses.append(response_cls.from_json(response))
        response['type'] = response_type
```