### PR TITLE
Fixed docs to include Friend Picker and Added FriendPickerMessage

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -64,6 +64,8 @@ These classes directly mirror the `message types used by the API <https://dev.ki
 
 .. autoclass:: kik.messages.ReadReceiptMessage
 
+.. autoclass:: kik.messages.FriendPickerMessage
+
 .. autoclass:: kik.messages.UnknownMessage
 
 Message Utilities
@@ -101,6 +103,10 @@ Keyboards and Responses
 .. autoclass:: kik.messages.responses.SuggestedResponse
 
 .. autoclass:: kik.messages.TextResponse
+   :members:
+   :show-inheritance:
+
+.. autoclass:: kik.messages.FriendPickerResponse
    :members:
    :show-inheritance:
 

--- a/kik/messages/__init__.py
+++ b/kik/messages/__init__.py
@@ -8,6 +8,7 @@ from kik.messages.sticker import StickerMessage
 from kik.messages.text import TextMessage
 from kik.messages.unknown import UnknownMessage
 from kik.messages.video import VideoMessage
+from kik.messages.friend_picker import FriendPickerMessage
 from kik.messages.utils import messages_from_json
 from kik.messages.keyboards import SuggestedResponseKeyboard, UnknownKeyboard
 from kik.messages.responses import TextResponse, FriendPickerResponse, UnknownResponse
@@ -18,4 +19,5 @@ from kik.messages.message import Message
 __all__ = ['TextMessage', 'LinkMessage', 'PictureMessage', 'ScanDataMessage', 'StartChattingMessage', 'StickerMessage',
            'VideoMessage', 'IsTypingMessage', 'ReceiptMessage', 'ReadReceiptMessage', 'DeliveryReceiptMessage',
            'UnknownMessage', 'SuggestedResponseKeyboard', 'UnknownKeyboard', 'TextResponse', 'FriendPickerResponse',
-           'UnknownResponse', 'messages_from_json', 'CustomAttribution', 'PresetAttributions', 'Message']
+           'UnknownResponse', 'messages_from_json', 'CustomAttribution', 'PresetAttributions', 'Message', 
+           'FriendPickerMessage']

--- a/kik/messages/__init__.py
+++ b/kik/messages/__init__.py
@@ -19,5 +19,5 @@ from kik.messages.message import Message
 __all__ = ['TextMessage', 'LinkMessage', 'PictureMessage', 'ScanDataMessage', 'StartChattingMessage', 'StickerMessage',
            'VideoMessage', 'IsTypingMessage', 'ReceiptMessage', 'ReadReceiptMessage', 'DeliveryReceiptMessage',
            'UnknownMessage', 'SuggestedResponseKeyboard', 'UnknownKeyboard', 'TextResponse', 'FriendPickerResponse',
-           'UnknownResponse', 'messages_from_json', 'CustomAttribution', 'PresetAttributions', 'Message', 
+           'UnknownResponse', 'messages_from_json', 'CustomAttribution', 'PresetAttributions', 'Message',
            'FriendPickerMessage']

--- a/kik/messages/friend_picker.py
+++ b/kik/messages/friend_picker.py
@@ -1,0 +1,18 @@
+from kik.messages.keyboard_message import Message
+
+
+class FriendPickerMessage(Message):
+    """
+    A friend picker message, as documented at `<https://dev.kik.com/#/docs/messaging#friend-picker-response-object>`_.
+    """
+    def __init__(self, picked=None, **kwargs):
+        super(FriendPickerMessage, self).__init__(type='friend-picker', **kwargs)
+        self.picked = picked
+
+    @classmethod
+    def property_mapping(cls):
+        mapping = super(FriendPickerMessage, cls).property_mapping()
+        mapping.update({
+            'picked': 'picked'
+        })
+        return mapping

--- a/kik/messages/utils.py
+++ b/kik/messages/utils.py
@@ -1,5 +1,6 @@
 from kik.messages import TextMessage, LinkMessage, PictureMessage, VideoMessage, StartChattingMessage, \
-    ScanDataMessage, StickerMessage, IsTypingMessage, DeliveryReceiptMessage, ReadReceiptMessage, UnknownMessage
+    ScanDataMessage, StickerMessage, IsTypingMessage, DeliveryReceiptMessage, ReadReceiptMessage, UnknownMessage, \
+    FriendPickerMessage
 
 incoming_type_mapping = {
     'text': TextMessage,
@@ -11,7 +12,8 @@ incoming_type_mapping = {
     'sticker': StickerMessage,
     'is-typing': IsTypingMessage,
     'delivery-receipt': DeliveryReceiptMessage,
-    'read-receipt': ReadReceiptMessage
+    'read-receipt': ReadReceiptMessage,
+    'friend-picker': FriendPickerMessage
 }
 
 

--- a/test/messages/test_messages.py
+++ b/test/messages/test_messages.py
@@ -140,10 +140,7 @@ class KikBotMessagesTest(TestCase):
                     'type': 'suggested',
                     'hidden': True,
                     'responses': [
-                        {
-                            'type': 'friend-picker',
-                            'body': 'foo'
-                        }
+                        {'type': 'friend-picker', 'body': 'foo'}
                     ]
                 }
             ]

--- a/test/messages/test_messages_incoming.py
+++ b/test/messages/test_messages_incoming.py
@@ -2,7 +2,7 @@ from unittest import TestCase
 
 from kik.messages import VideoMessage, UnknownMessage, TextMessage, StartChattingMessage, StickerMessage, \
     ScanDataMessage, PictureMessage, LinkMessage, IsTypingMessage, ReadReceiptMessage, DeliveryReceiptMessage, \
-    SuggestedResponseKeyboard, TextResponse, FriendPickerResponse
+    SuggestedResponseKeyboard, TextResponse, FriendPickerResponse, FriendPickerMessage
 
 
 class KikBotMessagesIncomingTest(TestCase):
@@ -244,6 +244,27 @@ class KikBotMessagesIncomingTest(TestCase):
         self.assertIs(None, message.mention)
         self.assertEqual(message.chat_id, 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
         self.assertEqual(message.message_ids, ['ff3ea373-576c-45d4-bdcd-9956a156301d'])
+        self.assertEqual(message.id, '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0')
+        self.assertEqual(message.timestamp, 1458336131)
+        self.assertIs(False, message.read_receipt_requested)
+
+    def test_friend_picker_message_incoming(self):
+        message = FriendPickerMessage.from_json({
+            'from': 'aleem',
+            'participants': ['aleem'],
+            'mention': None,
+            'chatId': 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2',
+            'picked': ['foobar'],
+            'id': '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0',
+            'timestamp': 1458336131,
+            'readReceiptRequested': False
+        })
+
+        self.assertEqual(message.from_user, 'aleem')
+        self.assertEqual(message.participants, ['aleem'])
+        self.assertIs(None, message.mention)
+        self.assertEqual(message.chat_id, 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2')
+        self.assertEqual(message.picked, ['foobar'])
         self.assertEqual(message.id, '8e7fc0ad-36aa-43dd-8c5f-e72f5f2ed7e0')
         self.assertEqual(message.timestamp, 1458336131)
         self.assertIs(False, message.read_receipt_requested)


### PR DESCRIPTION
Added FriendPickerMessage so a bot can get the proper type of message after a user picks a friend (Not UnknownMessage).

Documented FriendPickerMessage and FriendPickerResponse object types.